### PR TITLE
Release 0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 matrix:
   include:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+0.1.2
+- Remove use of pure function in module MinimalDXFan to support older compilers.
+
 0.1.1
 - Psychrolib: Switch from git submodule to subtree.
 - Psychrolib: Update to version 2.4.0.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 cmake_minimum_required(VERSION 3.1)
 project(MinimalDX Fortran)

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ If you are using _Minimal_**DX**, please make sure to cite the specific version 
 
 ## Copyright and License
 
-Copyright 2018 D. Meyer and R. Raustad. Licensed under [MIT](LICENSE.txt).
+Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under [MIT](LICENSE.txt).

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,4 +1,4 @@
-MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
+MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
 
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION.
 Do Not Translate or Localize.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 

--- a/src/cooling/minimal_dx_cooling.f90
+++ b/src/cooling/minimal_dx_cooling.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 !
 ! Description
 ! This module contains a simplified EnergyPlus subroutine for calculating the performance

--- a/src/cooling/minimal_dx_cooling_driver.f90
+++ b/src/cooling/minimal_dx_cooling_driver.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 module MinimalDXCoolingDriver
   !+ Contains a simplified EnergyPlus subroutine for simulating the performance of a DX cooling coil.

--- a/src/shared/minimal_dx_fan.f90
+++ b/src/shared/minimal_dx_fan.f90
@@ -60,7 +60,7 @@ module MinimalDXFan
   implicit none
 
   contains
-  pure function GetOnOffFan(Mode, MotEff, FanPower, MotInAirFrac, InletAirEnthalpy, AirMassFlowRate) result(OutletAirEnthalpy)
+  function GetOnOffFan(Mode, MotEff, FanPower, MotInAirFrac, InletAirEnthalpy, AirMassFlowRate) result(OutletAirEnthalpy)
     !+ Simplified version of SimOnOffFan subroutine in EnergyPlus
     !+ Given the mode of operation (on or off), fan motor efficiency, power of the fan, fraction of motor heat entering air stream
     !+ moist air enthaply of the air entering the fan, and mass flow rate, it returns the moist air enthaply of the air

--- a/src/shared/minimal_dx_fan.f90
+++ b/src/shared/minimal_dx_fan.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 !
 ! Description
 ! This module currently contains one function (SimpleFanOnOff) for simulating a simple on/off fan.

--- a/src/shared/psychro_wrapper.f90
+++ b/src/shared/psychro_wrapper.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 module PsychroWrapper
   !+ Wraps PsychroLib functions.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 include(ExternalProject)
 

--- a/tests/cooling/CMakeLists.txt
+++ b/tests/cooling/CMakeLists.txt
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 # Common files
 set(SRC_TEST_COOLING

--- a/tests/cooling/eplus_wrapper_cooling.f90
+++ b/tests/cooling/eplus_wrapper_cooling.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 module EPlusWrapperCooling
   !+ Initialise CalcDoe2DXCoil from EnergyPlusFortran and CalcDXCoolingCoil

--- a/tests/cooling/make_test_data_cooling.f90
+++ b/tests/cooling/make_test_data_cooling.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 program make_test_data_cooling
   !+ Generates test data for testing the cooling coils.

--- a/tests/cooling/test_cooling.f90
+++ b/tests/cooling/test_cooling.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 program test_cooling
   !+ Program to compare MinimalDX against original EnergyPlus implementation.

--- a/tests/debugging/CMakeLists.txt
+++ b/tests/debugging/CMakeLists.txt
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 # Program used for debugging
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod/test_cooling_point)

--- a/tests/debugging/test_cooling_point.f90
+++ b/tests/debugging/test_cooling_point.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 program  test_cooling_point
   !+ Program to compare MinimalDX against original EnergyPlus implementation.

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,5 +1,5 @@
-# MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-# Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+# MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+# Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 import subprocess
 import os

--- a/tests/shared/psychro_wrapper_eplus.f90
+++ b/tests/shared/psychro_wrapper_eplus.f90
@@ -1,5 +1,5 @@
-! MinimalDX version 0.1.1 (https://www.github.com/dmey/minimal-dx).
-! Copyright 2018 D. Meyer and R. Raustad. Licensed under MIT.
+! MinimalDX version 0.1.2 (https://www.github.com/dmey/minimal-dx).
+! Copyright 2018-2020 D. Meyer and R. Raustad. Licensed under MIT.
 
 module PsychroWrapper
   !+ Wraps PsychroLib functions.


### PR DESCRIPTION
Minor: remove use of pure function in module `MinimalDXFan` to support older compilers.